### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Roadmap is:
 
 # Use with CocoaPods
 
-To use this project inside an XCode project use CocoaPods
+To use this project inside an Xcode project use CocoaPods
 
 pod 'NodeKittenX', '~> 0.1.0'
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
